### PR TITLE
Block calls with failed verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [UNRELEASED]
 
+- Added ability to block calls with failed verification (requires Android >= 11 and advanced blocking mode)
 - Added icon to en-US fastlane metadata
 - Fixed fastlane folder names for language nb-NO
 - Fixed fastlane folder names for language pt-BR

--- a/app/src/main/java/fr/vinetos/tranquille/CallScreeningServiceImpl.java
+++ b/app/src/main/java/fr/vinetos/tranquille/CallScreeningServiceImpl.java
@@ -55,6 +55,7 @@ public class CallScreeningServiceImpl extends CallScreeningService {
             String number = null;
 
             if (!ignore) {
+
                 Uri handle = callDetails.getHandle();
                 LOG.trace("onScreenCall() handle: {}", handle);
 
@@ -98,8 +99,31 @@ public class CallScreeningServiceImpl extends CallScreeningService {
             }
 
             if (!ignore) {
-                numberInfo = numberInfoService.getNumberInfo(number,
-                        App.getSettings().getCachedAutoDetectedCountryCode(), false);
+                boolean isFailedVerification = false;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    if (callDetails.getCallerNumberVerificationStatus() ==
+                        Connection.VERIFICATION_STATUS_FAILED
+                    ) {
+                        LOG.trace("onScreenCall() verification failed");
+                        isFailedVerification = true;
+                    }
+                    if (callDetails.getCallerNumberVerificationStatus() ==
+                        Connection.VERIFICATION_STATUS_NOT_VERIFIED
+                    ) {
+                        LOG.trace("onScreenCall() not verified");
+                    }
+                    if (callDetails.getCallerNumberVerificationStatus() ==
+                        Connection.VERIFICATION_STATUS_PASSED
+                    ) {
+                        LOG.trace("onScreenCall() verification passed");
+                    }
+                }
+                numberInfo = numberInfoService.getNumberInfo(
+                    number,
+                    App.getSettings().getCachedAutoDetectedCountryCode(),
+                    false,
+                    isFailedVerification
+                );
 
                 shouldBlock = numberInfoService.shouldBlock(numberInfo);
             }

--- a/app/src/main/java/fr/vinetos/tranquille/NotificationHelper.java
+++ b/app/src/main/java/fr/vinetos/tranquille/NotificationHelper.java
@@ -224,11 +224,20 @@ public class NotificationHelper {
     private static String getBlockedDescription(Context context, NumberInfo numberInfo) {
         String text = numberInfo.name;
 
+        text = concat(text, "\n", getFailedVerificationDescriptionPart(context, numberInfo));
         text = concat(text, "\n", getCommunityDescriptionPart(context, numberInfo));
         text = concat(text, "\n", getDenylistDescriptionPart(context, numberInfo));
         text = concat(text, "\n", getNumberDescriptionPart(context, numberInfo));
 
         return text;
+    }
+
+    private static String getFailedVerificationDescriptionPart(Context context, NumberInfo numberInfo) {
+        if (numberInfo.isFailedVerification) {
+            return context.getString(R.string.info_failed_verification);
+        }
+
+        return null;
     }
 
     private static String getNumberDescriptionPart(Context context, NumberInfo numberInfo) {

--- a/app/src/main/java/fr/vinetos/tranquille/NumberInfoUtils.java
+++ b/app/src/main/java/fr/vinetos/tranquille/NumberInfoUtils.java
@@ -9,6 +9,10 @@ import dummydomain.yetanothercallblocker.sia.model.NumberCategory;
 public class NumberInfoUtils {
 
     public static String getShortDescription(Context context, NumberInfo numberInfo) {
+        if (numberInfo.isFailedVerification) {
+            return context.getString(R.string.info_failed_verification);
+        }
+
         if (numberInfo.communityDatabaseItem != null) {
             NumberCategory category = NumberCategory.getById(
                     numberInfo.communityDatabaseItem.getCategory());

--- a/app/src/main/java/fr/vinetos/tranquille/RootSettingsFragment.java
+++ b/app/src/main/java/fr/vinetos/tranquille/RootSettingsFragment.java
@@ -110,6 +110,7 @@ public class RootSettingsFragment extends BaseSettingsFragment {
             return true;
         };
         setPrefChangeListener(Settings.PREF_BLOCK_NEGATIVE_SIA_NUMBERS, callBlockingListener);
+        setPrefChangeListener(Settings.PREF_BLOCK_FAILED_VERIFICATION, callBlockingListener);
         setPrefChangeListener(Settings.PREF_BLOCK_HIDDEN_NUMBERS, callBlockingListener);
         setPrefChangeListener(Settings.PREF_BLOCK_DENYLISTED, callBlockingListener);
 
@@ -128,6 +129,11 @@ public class RootSettingsFragment extends BaseSettingsFragment {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             callScreeningPref.setVisible(false);
         }
+
+        SwitchPreferenceCompat blockFailedVerificationPref =
+            requirePreference(Settings.PREF_BLOCK_FAILED_VERIFICATION);
+        blockFailedVerificationPref.setVisible(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R);
+        blockFailedVerificationPref.setEnabled(callScreeningPref.isChecked());
 
         setPrefChangeListener(Settings.PREF_USE_MONITORING_SERVICE, (pref, newValue) -> {
             boolean enabled = Boolean.TRUE.equals(newValue);
@@ -211,8 +217,17 @@ public class RootSettingsFragment extends BaseSettingsFragment {
     private void updateCallScreeningPreference() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return;
 
+        boolean isCallScreeningHeld = PermissionHelper.isCallScreeningHeld(requireContext());
         this.<SwitchPreferenceCompat>requirePreference(PREF_USE_CALL_SCREENING_SERVICE)
-                .setChecked(PermissionHelper.isCallScreeningHeld(requireContext()));
+            .setChecked(isCallScreeningHeld);
+
+        this.<SwitchPreferenceCompat>requirePreference(Settings.PREF_BLOCK_FAILED_VERIFICATION)
+            .setEnabled(isCallScreeningHeld);
+
+        this.<SwitchPreferenceCompat>requirePreference(Settings.PREF_BLOCK_FAILED_VERIFICATION)
+            .setChecked(
+                isCallScreeningHeld && App.getSettings().getBlockFailedVerificationEnabled()
+            );
     }
 
     private void updateBlockedCallNotificationsPreference() {

--- a/app/src/main/java/fr/vinetos/tranquille/Settings.java
+++ b/app/src/main/java/fr/vinetos/tranquille/Settings.java
@@ -1,6 +1,7 @@
 package fr.vinetos.tranquille;
 
 import android.content.Context;
+import android.os.Build;
 import android.text.TextUtils;
 
 import androidx.appcompat.app.AppCompatDelegate;
@@ -21,6 +22,7 @@ public class Settings extends GenericSettings {
 
     public static final String PREF_INCOMING_CALL_NOTIFICATIONS = "incomingCallNotifications";
     public static final String PREF_BLOCK_NEGATIVE_SIA_NUMBERS = "blockNegativeSiaNumbers";
+    public static final String PREF_BLOCK_FAILED_VERIFICATION = "blockFailedVerification";
     public static final String PREF_BLOCK_HIDDEN_NUMBERS = "blockHiddenNumbers";
     public static final String PREF_BLOCK_DENYLISTED = "blockDenylisted";
     public static final String PREF_DENYLIST_IS_NOT_EMPTY = "denylistIsNotEmpty";
@@ -124,7 +126,10 @@ public class Settings extends GenericSettings {
     }
 
     public boolean getCallBlockingEnabled() {
-        return getBlockNegativeSiaNumbers() || getBlockHiddenNumbers() || getDenylistEnabled();
+        return getBlockNegativeSiaNumbers() ||
+            getBlockHiddenNumbers() ||
+            getDenylistEnabled() ||
+            getBlockFailedVerificationEnabled();
     }
 
     public boolean getBlockNegativeSiaNumbers() {
@@ -133,6 +138,19 @@ public class Settings extends GenericSettings {
 
     public void setBlockNegativeSiaNumbers(boolean block) {
         setBoolean(PREF_BLOCK_NEGATIVE_SIA_NUMBERS, block);
+    }
+
+    /**
+     * STIR verification is only available from Android 11
+     */
+    public boolean getBlockFailedVerificationEnabled() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            PermissionHelper.isCallScreeningHeld(context) &&
+            getBoolean(PREF_BLOCK_FAILED_VERIFICATION);
+    }
+
+    public void setBlockFailedVerificationEnabled(boolean block) {
+        setBoolean(PREF_BLOCK_FAILED_VERIFICATION, block);
     }
 
     public boolean getBlockHiddenNumbers() {

--- a/app/src/main/java/fr/vinetos/tranquille/data/NumberInfo.java
+++ b/app/src/main/java/fr/vinetos/tranquille/data/NumberInfo.java
@@ -6,7 +6,7 @@ import dummydomain.yetanothercallblocker.sia.model.database.FeaturedDatabaseItem
 public class NumberInfo {
 
     public enum BlockingReason {
-        HIDDEN_NUMBER, SIA_RATING, DENYLISTED
+        HIDDEN_NUMBER, SIA_RATING, DENYLISTED, FAILED_VERIFICATION
     }
 
     public enum Rating {
@@ -19,6 +19,7 @@ public class NumberInfo {
 
     // info from various sources
     public boolean isHiddenNumber;
+    public boolean isFailedVerification;
     public ContactItem contactItem;
     public CommunityDatabaseItem communityDatabaseItem;
     public FeaturedDatabaseItem featuredDatabaseItem;

--- a/app/src/main/java/fr/vinetos/tranquille/data/NumberInfoService.java
+++ b/app/src/main/java/fr/vinetos/tranquille/data/NumberInfoService.java
@@ -48,11 +48,25 @@ public class NumberInfoService {
         this.denylistService = denylistService;
     }
 
-    public NumberInfo getNumberInfo(String number, String countryCode, boolean full) {
+    public NumberInfo getNumberInfo(
+        String number,
+        String countryCode,
+        boolean full
+    ) {
+        return getNumberInfo(number, countryCode, full, false);
+    }
+
+    public NumberInfo getNumberInfo(
+        String number,
+        String countryCode,
+        boolean full,
+        boolean isFailedVerification
+    ) {
         LOG.debug("getNumberInfo({}, {}, {}) started", number, countryCode, full);
 
         NumberInfo numberInfo = new NumberInfo();
         numberInfo.number = number;
+        numberInfo.isFailedVerification = isFailedVerification;
 
         if (hiddenNumberDetector != null) {
             numberInfo.isHiddenNumber = hiddenNumberDetector.isHiddenNumber(number);
@@ -130,6 +144,12 @@ public class NumberInfoService {
     }
 
     protected NumberInfo.BlockingReason getBlockingReason(NumberInfo numberInfo) {
+        // We must do that prior to contact checking as we don't want someone to impersonate a
+        // contact
+        if (numberInfo.isFailedVerification && settings.getBlockFailedVerificationEnabled()) {
+            return NumberInfo.BlockingReason.FAILED_VERIFICATION;
+        }
+
         if (numberInfo.contactItem != null) return null;
 
         if (numberInfo.isHiddenNumber && settings.getBlockHiddenNumbers()) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -73,6 +73,8 @@
     <string name="block_negative_sia_short">Bloquer selon la notation</string>
     <string name="block_negative_sia">Blocage en fonction de la notation</string>
     <string name="block_negative_sia_numbers_summary">Bloquer les appels provenant de numéros ayant une note négative (sur la base d\'une base de données communautaire))</string>
+    <string name="block_failed_verification">Bloquer en cas d’échec de vérification</string>
+    <string name="block_failed_verification_summary">Bloquer les appels échouant la vérification STIR, indiquant que l’appel entrant pourrait ne pas être véritablement du numéro indiqué. Cela peut se produire si, par exemple, l’appelant utilise un numéro usurpé. Nécessite le mode de blocage d’appel avancé.</string>
     <string name="block_hidden_number">Bloquer les numéros masqués</string>
     <string name="block_hidden_number_summary">Bloquer les appels provenant de numéros masqués. Peut fonctionner différemment (meilleur ou pire) en « Mode de blocage d\'appel avancé »</string>
     <string name="use_call_screening_service">Mode de blocage d\'appel avancé</string>
@@ -122,6 +124,7 @@
     <string name="open_db_management_activity">Gérer la base de données</string>
     <string name="add_to_denylist">Ajouter à la liste de blocage</string>
     <string name="info_in_denylist_contact">Sur la liste de blocage (les contacts ne sont pas bloqués)</string>
+    <string name="info_failed_verification">Vérification échouée</string>
     <string name="info_in_denylist">Sur la liste de blocage</string>
     <string name="number_pattern_hint">Entrez le numéro au format +INDICATIF-PAYS (comme Android l’indique dans votre clavier). Utilisez « * » comme caractère générique pour zéro ou plus de chiffres, et « # » pour exactement un chiffre.</string>
     <string name="number_pattern_empty">Modèle vide</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,8 @@
     <string name="block_negative_sia_short">Block by rating</string>
     <string name="block_negative_sia">Block based on rating</string>
     <string name="block_negative_sia_numbers_summary">Block calls from numbers with negative rating (based on a community database)</string>
+    <string name="block_failed_verification">Block failed verification</string>
+    <string name="block_failed_verification_summary">Block calls failing the STIR verification, indicating that the incoming call may not actually be from the indicated number. This could occur if, for example, the caller is using an impersonated phone number. Requires “Advanced call blocking mode”.</string>
     <string name="block_hidden_number">Block hidden numbers</string>
     <string name="block_hidden_number_summary">Block calls from hidden numbers. May work differently (better or worse) in \"Advanced call blocking mode\"</string>
     <string name="block_denylisted_short">Enable denylist</string>
@@ -205,6 +207,7 @@
     <string name="contacts_are_not_blocked_denylist_notice">Calls from contacts are never blocked (even on pattern match)</string>
     <string name="contacts_are_not_blocked_not_enabled">Calls from contacts may be blocked because the \"Use contacts\" option is not enabled!</string>
     <string name="contacts_are_not_blocked_no_permission">Calls from contacts may be blocked because the \"Contacts\" permission is not granted!</string>
+    <string name="info_failed_verification">Failed verification</string>
     <string name="info_in_denylist">In denylist</string>
     <string name="info_in_denylist_contact">In denylist (contacts are not blocked)</string>
     <string name="add_to_denylist">Add to denylist</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -51,6 +51,10 @@
             app:persistent="false"
             app:summary="@string/use_call_screening_service_summary"
             app:title="@string/use_call_screening_service" />
+        <SwitchPreferenceCompat
+            app:key="blockFailedVerification"
+            app:summary="@string/block_failed_verification_summary"
+            app:title="@string/block_failed_verification" />
     </PreferenceCategory>
 
     <SwitchPreferenceCompat


### PR DESCRIPTION
Fix #21 

Requires Android >= 11 and advanced blocking mode.
Successfully show a blocked call notification when the call fails verification.

However, this won't show in the call logs, because as far as I can see, Android doesn't store this information in call logs.
If we want to show it, we would need to duplicate all calls in a local database table, and have some way to make received calls match with Android system logs. Not a trivial work.

At least the feature is working as intended, so I believe this can be a good first step.